### PR TITLE
Catch errors in async i/o; prep for 0.0.5 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # build with 'python ./setup.py install'
 from distutils.core import setup
 
-VERSION = "0.0.4"
+VERSION = "0.0.5"
 
 setup(
     name = 'carp-rpc',
@@ -13,7 +13,7 @@ setup(
     author = 'Bill Gribble',
     author_email = 'grib@billgribble.com',
     url = 'https://github.com/bgribble/carp',
-    download_url = 'https://github.com/bgribble/carp/archive/refs/tags/v0.0.4.tar.gz',
+    download_url = 'https://github.com/bgribble/carp/archive/refs/tags/v0.0.5.tar.gz',
     keywords = ['rpc', 'protobuf', 'json'],
     install_requires = [
         "protobuf", "python-dateutil",


### PR DESCRIPTION
This release has a fix for one issue I discovered while testing [mfp](https://github.com/bgribble/mfp): When the async message handler is being run as a background task, errors that it raises were not caught as expected. This led to some spurious logging of errors when closing down the app. 